### PR TITLE
feat: watch /now output

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,10 @@ PROMPT_CACHE_TTL_SEC=3600
 PERMISSION_WATCH_SEC=120
 PERMISSION_WATCH_INTERVAL_SEC=2
 PERMISSION_WATCH_PATTERN=(Allow once|Allow always|Approve|Permission|許可|承認)
+# /now watch
+NOW_WATCH_INTERVAL_SEC=1
+NOW_WATCH_IDLE_COUNT=3
+NOW_WATCH_TIMEOUT_SEC=180
 # Command filtering (comma-separated patterns; use "all" to match everything)
 # COMMAND_ALLOWLIST=all
 # COMMAND_DENYLIST=sudo,rm -rf,/\\brm\\b/,mkfs,dd,/\\bshutdown\\b/,/\\breboot\\b/,/curl\\s+.*\\|\\s*sh/,/wget\\s+.*\\|\\s*sh/

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ cp .env.sample .env
 - `PROMPT_CACHE_TTL_SEC` – retention window for cached prompts; maintenance workers purge expired entries.
 - `CHANNEL_IDLE_NOTIFY_SEC` / `CHANNEL_IDLE_NOTIFY_COOLDOWN_SEC` – idle notification interval and cooldown (per channel).
 - `PERMISSION_WATCH_SEC` / `PERMISSION_WATCH_INTERVAL_SEC` / `PERMISSION_WATCH_PATTERN` – after sending Enter, watch tmux output for approval prompts and post a snippet to the thread.
+- `NOW_WATCH_INTERVAL_SEC` / `NOW_WATCH_IDLE_COUNT` / `NOW_WATCH_TIMEOUT_SEC` – `/now` polling interval, consecutive idle count to reply, and timeout before prompting to continue.
 - `COMMAND_ALLOWLIST` / `COMMAND_DENYLIST` – comma-separated patterns; include `all` to allow/deny everything. Default behavior blocks `rm` (use `\rm` to bypass).
 
 Command filter notes:
@@ -211,7 +212,7 @@ python slack_tmux_bridge.py
    - Numeric-only messages send automatically.
    - `text == "/sessions"` (or `\/sessions`) shows connected channel names and directories.
    - `text == "/dir"` (or `\/dir`) shows the connected directory for the channel.
-   - `text == "/now"` (or `\/now`) captures the current Gemini output once.
+   - `text == "/now"` (or `\/now`) polls for pane changes and replies after the output stops changing; if it keeps changing for `NOW_WATCH_TIMEOUT_SEC`, it posts a timeout message with a “continue watch” button.
    - `text == "/ctlc"` (or `\/ctlc`) sends Ctrl+C to the connected tmux pane.
    - If the saved pane target differs from the current pane resolved via `pane_id`, the bridge prompts to confirm updating the connection before running.
 2. For normal executions, the bridge does not post results; the AI agent replies in the thread using the appended instruction. `/now` still captures output once and replies in the thread.
@@ -235,7 +236,7 @@ python slack_tmux_bridge.py
 
 - `/sessions`: Slack command that posts a list of channel names and connected directories.
 - `/dir`: Slack command that returns the connected directory.
-- `/now`: Slack command that captures the latest Gemini output once.
+- `/now`: Slack command that waits until pane output stabilizes, then posts the capture (timeout offers a continue button).
 - `/ctlc`: Slack command that sends Ctrl+C to the connected tmux pane.
 - `goslack.py`: Registers the current tmux pane with the target channel, cleans up duplicates, and supports `list`/`rm` (numbered), `--add`, and optional `--channel` override for session maintenance.
 

--- a/docs/L2_development/architecture_design.md
+++ b/docs/L2_development/architecture_design.md
@@ -64,4 +64,4 @@ tmux (Gemini CLI)
 
 # セキュリティ観点
 - コマンド allowlist/denylist による危険操作の制限。根拠: slack_tmux_bridge.py:150-168
-- トークンは .env で管理し、リポジトリに含めない。根拠: README.md:54-76 / .env.sample:1-24
+- トークンは .env で管理し、リポジトリに含めない。根拠: README.md:54-76 / .env.sample:1-27

--- a/docs/L2_development/development_setup.md
+++ b/docs/L2_development/development_setup.md
@@ -6,7 +6,7 @@ Evidence:
 - README.md:114-170
 - requirements.txt:1-3
 - requirements-dev.txt:1
-- .env.sample:1-24
+- .env.sample:1-27
 - slack_tmux_bridge.py:22-55
 - goslack.py:18-21
 - launchd/com.slack_tmux_bridge.plist:1-23
@@ -18,7 +18,7 @@ Evidence:
 
 # 初期セットアップ手順
 1. 仮想環境を作成し依存関係をインストールする。根拠: README.md:29-37
-2. `.env.sample` を `.env` にコピーし、トークン等を設定する。根拠: README.md:54-60 / .env.sample:1-16
+2. `.env.sample` を `.env` にコピーし、トークン等を設定する。根拠: README.md:54-60 / .env.sample:1-27
 3. tmux 内で Gemini CLI を起動する。根拠: README.md:189-193
 4. 対象ペインで `python goslack.py` を実行し、チャンネルとペインを紐付ける。根拠: README.md:189-196 / goslack.py:285-359
 5. `python slack_tmux_bridge.py` を起動する。根拠: README.md:197-203
@@ -41,12 +41,15 @@ Evidence:
 - PERMISSION_WATCH_SEC
 - PERMISSION_WATCH_INTERVAL_SEC
 - PERMISSION_WATCH_PATTERN
+- NOW_WATCH_INTERVAL_SEC
+- NOW_WATCH_IDLE_COUNT
+- NOW_WATCH_TIMEOUT_SEC
 - COMMAND_ALLOWLIST
 - COMMAND_DENYLIST
-根拠: .env.sample:1-24 / slack_tmux_bridge.py:22-55 / goslack.py:18-21
+根拠: .env.sample:1-27 / slack_tmux_bridge.py:22-58 / goslack.py:18-21
 
 # 補足（.env.sample 未記載の項目）
-- `TMUX_BIN` と `CHANNEL_IDLE_NOTIFY_*` はコード上で参照されるが、`.env.sample` には記載がない。根拠: slack_tmux_bridge.py:24,50-51 / .env.sample:1-24
+- `TMUX_BIN` と `CHANNEL_IDLE_NOTIFY_*` はコード上で参照されるが、`.env.sample` には記載がない。根拠: slack_tmux_bridge.py:24,53-54 / .env.sample:1-27
 
 # 開発コマンド一覧
 | コマンド | 説明 | 根拠 |
@@ -59,6 +62,7 @@ Evidence:
 | `python goslack.py list` | セッション一覧 | README.md:96-104 |
 | `python goslack.py rm <number>` | セッション削除 | README.md:106-110 |
 | `pytest` | テスト実行 | requirements-dev.txt:1 |
+| `./scripts/test_now.sh` | `/now` 監視テストの短縮実行 | scripts/test_now.sh:1-20 |
 
 # テスト/リント/フォーマット手順
 - テスト: `pytest`。根拠: requirements-dev.txt:1 / test/ 配下

--- a/docs/L3_implementation/specification.md
+++ b/docs/L3_implementation/specification.md
@@ -53,6 +53,9 @@
 | `PERMISSION_WATCH_SEC` | `120` | 承認待ち監視時間 | 承認要求をSlackへ可視化するため |
 | `PERMISSION_WATCH_INTERVAL_SEC` | `2` | 監視間隔 | 負荷と反応速度のバランス |
 | `PERMISSION_WATCH_PATTERN` | `(Allow once|Allow always|Approve|Permission|許可|承認)` | 承認検知パターン | 承認要求検知をチューニング可能にするため |
+| `NOW_WATCH_INTERVAL_SEC` | `1` | `/now` 監視のポーリング間隔 | 出力変化の検知間隔を調整するため |
+| `NOW_WATCH_IDLE_COUNT` | `3` | `/now` の停止判定回数 | 変化が止まったとみなす閾値 |
+| `NOW_WATCH_TIMEOUT_SEC` | `180` | `/now` 監視タイムアウト | 変化が続く場合の打ち切りと継続促しのため |
 | `TMUX_BIN` | 省略時 `tmux` | tmux の絶対パス | PATH に tmux が無い場合（launchd など）に必要 |
 
 ---
@@ -113,7 +116,7 @@ python goslack.py rm 4
 - `/bye` は特別扱いで接続解除する。
 - `/dir` は接続中ディレクトリを返す（記録がある場合）。
 - `/sessions` は接続中のチャンネル名とディレクトリの一覧を返す。
-- `/now` は現在の tmux 出力を**単発取得**して返信する。
+- `/now` は tmux 出力の変化を監視し、変化が止まったタイミングで取得結果を返信する（タイムアウト時は継続ボタンを提示）。
 - `/ctlc` は tmux に Ctrl+C を送信する。
 - `active_sessions.json` に登録がないチャンネルは**無視**。
 - 送信時は `pane_id` から現在の `session:window.pane` を解決し、解決できない場合は送信しない（誤送信防止）。
@@ -166,8 +169,10 @@ python goslack.py rm 4
 
 ## 7. 応答生成（コマンド系のみ）
 
-### 7.1 単発取得
-- `/now` などの**コマンド系のみ**、`tmux capture-pane` を 1 回実行して出力を取得。
+### 7.1 `/now` の監視取得
+- `/now` は `NOW_WATCH_INTERVAL_SEC` 間隔で tmux 出力を監視する。
+- 連続 `NOW_WATCH_IDLE_COUNT` 回変化がなければ、`tmux capture-pane` で取得して返信する。
+- 変化が `NOW_WATCH_TIMEOUT_SEC` を超えて続く場合はタイムアウトを通知し、「監視を継続」ボタンを提示する。
 - 実行ボタンによる通常の実行では、ブリッジは結果投稿を行わない。
 
 ### 7.2 抽出ロジック

--- a/docs/L3_implementation/specification_summary.md
+++ b/docs/L3_implementation/specification_summary.md
@@ -41,11 +41,11 @@ Evidence:
 # 入力種別と UX
 - 数字のみ: 事前に画面/履歴をクリアし、即時実行する。根拠: slack_tmux_bridge.py:264-272,822-843
 - テキスト: 入力を tmux に送った後、Slack のボタン操作で Enter を送信する。根拠: slack_tmux_bridge.py:844-890,947-972
-- `/sessions` `/dir` `/now` `/ctlc` などのコマンドは即時処理する。根拠: slack_tmux_bridge.py:668-685
+- `/sessions` `/dir` `/now` `/ctlc` などのコマンドは即時処理する。根拠: slack_tmux_bridge.py:812-833
 
 # 返信の取り扱い
 - 通常の実行結果は AI エージェントがスレッドに返信する前提で、プロンプト末尾に返信指示を付与する。根拠: README.md:10 / slack_tmux_bridge.py:601-607
-- `/now` や「👀 Geminiを見る」は tmux 出力を単発取得して返信する。根拠: README.md:215 / slack_tmux_bridge.py:864-877,1223-1243
+- `/now` は tmux 出力の変化を監視し、停止後に出力を返信する（タイムアウト時は継続ボタン）。「👀 Geminiを見る」は単発取得して返信する。根拠: slack_tmux_bridge.py:466-531,1284-1304
 - 承認要求が発生した場合の見落としを防ぐため、Enter 送信後に tmux 出力を監視して該当パターンが出たらスレッドに抜粋を投稿する。根拠: slack_tmux_bridge.py:415-460,822-843,947-972
 
 # tmux 入出力制御

--- a/scripts/test_now.sh
+++ b/scripts/test_now.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_PY="$ROOT_DIR/venv/bin/python"
+
+if [ ! -x "$VENV_PY" ]; then
+  echo "venv python not found at $VENV_PY" >&2
+  exit 1
+fi
+
+if [ ! -f "$ROOT_DIR/.env" ]; then
+  echo ".env not found at $ROOT_DIR/.env" >&2
+  exit 1
+fi
+
+set -a
+source "$ROOT_DIR/.env"
+set +a
+
+exec "$VENV_PY" -m pytest "$ROOT_DIR/test/test_slack_bridge_sessions.py" -k now "$@"

--- a/slack_tmux_bridge.py
+++ b/slack_tmux_bridge.py
@@ -56,6 +56,10 @@ PERMISSION_WATCH_PATTERN = os.environ.get(
     "PERMISSION_WATCH_PATTERN",
     r"(Allow once|Allow always|Approve|Permission|許可|承認)",
 )
+# /now watch (pane change polling)
+NOW_WATCH_INTERVAL_SEC = float(os.environ.get("NOW_WATCH_INTERVAL_SEC", "1"))
+NOW_WATCH_IDLE_COUNT = int(os.environ.get("NOW_WATCH_IDLE_COUNT", "3"))
+NOW_WATCH_TIMEOUT_SEC = int(os.environ.get("NOW_WATCH_TIMEOUT_SEC", "180"))
 
 # =====================
 # logging & utility
@@ -454,6 +458,67 @@ def _start_permission_watch(thread_ts: str, channel_id: str, tmux_target: str):
         return
     watcher = threading.Thread(
         target=_watch_permission_prompt,
+        args=(thread_ts, channel_id, tmux_target),
+        daemon=True,
+    )
+    watcher.start()
+
+def _watch_now_output(thread_ts: str, channel_id: str, tmux_target: str):
+    if not thread_ts or not channel_id or not tmux_target:
+        return
+    if NOW_WATCH_INTERVAL_SEC <= 0 or NOW_WATCH_IDLE_COUNT <= 0 or NOW_WATCH_TIMEOUT_SEC <= 0:
+        _capture_and_reply_once(thread_ts, channel_id, tmux_target, "")
+        return
+
+    start_ts = time.time()
+    idle_count = 0
+    try:
+        last_content = strip_ansi(capture_tmux(tmux_target, lines=True))
+    except Exception as e:
+        log(f"/now watch capture failed: {e}")
+        last_content = ""
+
+    while True:
+        if time.time() - start_ts >= NOW_WATCH_TIMEOUT_SEC:
+            _post_message(
+                channel_id,
+                "⏳ 監視がタイムアウトしました。続けますか？",
+                thread_ts=thread_ts,
+                blocks=[
+                    {
+                        "type": "actions",
+                        "elements": [
+                            {
+                                "type": "button",
+                                "text": {"type": "plain_text", "text": "監視を継続"},
+                                "action_id": "continue_now_watch",
+                            }
+                        ],
+                    }
+                ],
+            )
+            return
+
+        time.sleep(NOW_WATCH_INTERVAL_SEC)
+        try:
+            current_content = strip_ansi(capture_tmux(tmux_target, lines=True))
+        except Exception as e:
+            log(f"/now watch capture failed: {e}")
+            current_content = last_content
+
+        if current_content != last_content:
+            last_content = current_content
+            idle_count = 0
+            continue
+
+        idle_count += 1
+        if idle_count >= NOW_WATCH_IDLE_COUNT:
+            _capture_and_reply_once(thread_ts, channel_id, tmux_target, "")
+            return
+
+def _start_now_watch(thread_ts: str, channel_id: str, tmux_target: str):
+    watcher = threading.Thread(
+        target=_watch_now_output,
         args=(thread_ts, channel_id, tmux_target),
         daemon=True,
     )
@@ -869,11 +934,7 @@ def _handle_now_command(channel_id: str, thread_ts: str, tmux_target: str) -> bo
         "🔄 現在の状態を取得しています...",
         thread_ts=thread_ts
     )
-    threading.Thread(
-        target=_capture_and_reply_once,
-        args=(thread_ts, channel_id, tmux_target, ""),
-        daemon=True
-    ).start()
+    _start_now_watch(thread_ts, channel_id, tmux_target)
     return True
 
 def _handle_ctlc_command(channel_id: str, thread_ts: str, tmux_target: str) -> bool:
@@ -1241,6 +1302,25 @@ def handle_show_gemini(ack, body):
         "```" + out[-3500:] + "```",
         thread_ts=thread_ts
     )
+
+# =====================
+# Slack: 監視を継続（/now と同じ挙動）
+# =====================
+@app.action("continue_now_watch")
+def handle_continue_now_watch(ack, body):
+    ack()
+    log("BUTTON CLICKED: continue_now_watch")
+
+    channel_id = body["channel"]["id"]
+    thread_ts = _get_thread_ts_from_message(body["message"])
+    tmux_target = _get_tmux_target_or_notify(
+        channel_id,
+        message="⚠️ Error: No active tmux session for this channel. Run `goslack` in your terminal."
+    )
+    if not tmux_target:
+        return
+
+    _handle_now_command(channel_id, thread_ts, tmux_target)
 
 # =====================
 # Slack: rebind confirmation

--- a/test/test_slack_bridge_sessions.py
+++ b/test/test_slack_bridge_sessions.py
@@ -212,17 +212,11 @@ def test_now_command_starts_monitor_and_notifies_when_busy(monkeypatch):
     def _post_message(channel, text, thread_ts=None, blocks=None):
         sent.append((channel, text))
 
-    class DummyThread:
-        def __init__(self, target=None, args=(), daemon=None):
-            assert target == stb._capture_and_reply_once
-            self.args = args
-            self.daemon = daemon
-
-        def start(self):
-            calls["started"] = True
+    def _start_now_watch(thread_ts, channel_id, tmux_target):
+        calls["started"] = True
 
     monkeypatch.setattr(stb, "_post_message", _post_message)
-    monkeypatch.setattr(stb.threading, "Thread", DummyThread)
+    monkeypatch.setattr(stb, "_start_now_watch", _start_now_watch)
 
     stb._handle_now_command("C1", "thread1", "1:1.0")
 
@@ -261,6 +255,63 @@ def test_now_uses_parent_thread_ts(monkeypatch):
     stb._handle_now_command("C1", "parent-ts", "1:1.0")
 
     assert any(ts == "parent-ts" for _, _, ts in sent)
+
+
+def test_now_watch_replies_after_idle(monkeypatch):
+    calls = {"captured": 0}
+
+    monkeypatch.setattr(stb, "NOW_WATCH_INTERVAL_SEC", 1.0)
+    monkeypatch.setattr(stb, "NOW_WATCH_IDLE_COUNT", 3)
+    monkeypatch.setattr(stb, "NOW_WATCH_TIMEOUT_SEC", 180)
+    monkeypatch.setattr(stb.time, "sleep", lambda *_: None)
+    monkeypatch.setattr(stb, "capture_tmux", lambda *_args, **_kwargs: "same-output")
+
+    def _capture_and_reply_once(thread_ts, channel_id, tmux_target, prompt=""):
+        calls["captured"] += 1
+
+    monkeypatch.setattr(stb, "_capture_and_reply_once", _capture_and_reply_once)
+
+    stb._watch_now_output("thread1", "C1", "1:1.0")
+
+    assert calls["captured"] == 1
+
+
+def test_now_watch_timeout_posts_continue_button(monkeypatch):
+    sent = []
+    counter = {"i": 0}
+
+    monkeypatch.setattr(stb, "NOW_WATCH_INTERVAL_SEC", 1.0)
+    monkeypatch.setattr(stb, "NOW_WATCH_IDLE_COUNT", 999)
+    monkeypatch.setattr(stb, "NOW_WATCH_TIMEOUT_SEC", 2)
+    monkeypatch.setattr(stb.time, "sleep", lambda *_: None)
+
+    def _post_message(channel, text, thread_ts=None, blocks=None):
+        sent.append((channel, text, blocks))
+
+    def _capture_tmux(*_args, **_kwargs):
+        counter["i"] += 1
+        return f"output-{counter['i']}"
+
+    class TimeStub:
+        def __init__(self):
+            self.current = 0
+
+        def __call__(self):
+            self.current += 1
+            return self.current
+
+    monkeypatch.setattr(stb, "_post_message", _post_message)
+    monkeypatch.setattr(stb, "capture_tmux", _capture_tmux)
+    monkeypatch.setattr(stb.time, "time", TimeStub())
+
+    stb._watch_now_output("thread1", "C1", "1:1.0")
+
+    assert any("タイムアウト" in text for _, text, _ in sent)
+    assert any(
+        blocks
+        and any(e.get("action_id") == "continue_now_watch" for e in blocks[0].get("elements", []))
+        for _, _, blocks in sent
+    )
 
 
 def test_command_menu_blocks_shape():


### PR DESCRIPTION
## 作業内容概要
- /now を監視ポーリング方式に変更し、停止検知で返信・タイムアウト時に継続ボタンを提示
- NOW_WATCH_* の環境変数を追加して挙動を調整可能に
- /now 監視のテストと実行用スクリプトを追加

## 変更ファイルごとの修正内容となぜその修正を行ったのかの理由
- slack_tmux_bridge.py: /now の監視ロジックと継続ボタンの action を追加。要件の「変化停止時返信」「タイムアウト時継続ボタン」を満たすため
- .env.sample: NOW_WATCH_* を追加。運用側で監視間隔/停止判定/タイムアウトを調整可能にするため
- README.md: /now の挙動と NOW_WATCH_* を追記。利用者が正しい挙動を理解できるようにするため
- docs/L3_implementation/specification.md: /now の監視仕様と環境変数を反映。仕様書を実装に一致させるため
- docs/L3_implementation/specification_summary.md: /now の監視挙動に更新。要約仕様を実装に一致させるため
- docs/L2_development/development_setup.md: NOW_WATCH_* とテストスクリプトを追記。開発手順を明確化するため
- docs/L2_development/architecture_design.md: .env.sample 参照行の更新。エビデンスの整合性確保のため
- test/test_slack_bridge_sessions.py: /now 監視のテスト更新・追加。新挙動の回帰防止のため
- scripts/test_now.sh: /now テストの簡易実行スクリプトを追加。ローカル実行を容易にするため

## 留意点
- /now の監視は NOW_WATCH_* の値に依存します。.env の設定を反映するため、ブリッジ再起動が必要です。
- テスト実行時は .env の Slack トークンが必要です。