### PR TITLE
feat: add codex notify thread reply and execute result mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,6 +23,8 @@ PERMISSION_WATCH_PATTERN=(Allow once|Allow always|Approve|Permission|許可|承�
 NOW_WATCH_INTERVAL_SEC=1
 NOW_WATCH_IDLE_COUNT=3
 NOW_WATCH_TIMEOUT_SEC=180
+# Execute button result handling: poll | notify | both
+EXECUTE_RESULT_MODE=poll
 # Command filtering (comma-separated patterns; use "all" to match everything)
 # COMMAND_ALLOWLIST=all
 # COMMAND_DENYLIST=sudo,rm -rf,/\\brm\\b/,mkfs,dd,/\\bshutdown\\b/,/\\breboot\\b/,/curl\\s+.*\\|\\s*sh/,/wget\\s+.*\\|\\s*sh/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ cp .env.sample .env
 - `CHANNEL_IDLE_NOTIFY_SEC` / `CHANNEL_IDLE_NOTIFY_COOLDOWN_SEC` – idle notification interval and cooldown (per channel).
 - `PERMISSION_WATCH_SEC` / `PERMISSION_WATCH_INTERVAL_SEC` / `PERMISSION_WATCH_PATTERN` – after sending Enter, watch tmux output for approval prompts and post a snippet to the thread.
 - `NOW_WATCH_INTERVAL_SEC` / `NOW_WATCH_IDLE_COUNT` / `NOW_WATCH_TIMEOUT_SEC` – `/now` polling interval, consecutive idle count to reply, and timeout before prompting to continue.
+- `EXECUTE_RESULT_MODE` – behavior after pressing “Execute (Enter)”: `poll` (existing watch), `notify` (Codex notify only), `both` (run both).
 - `COMMAND_ALLOWLIST` / `COMMAND_DENYLIST` – comma-separated patterns; include `all` to allow/deny everything. Default behavior blocks `rm` (use `\rm` to bypass).
 
 Command filter notes:
@@ -239,6 +240,7 @@ python slack_tmux_bridge.py
 - `/now`: Slack command that waits until pane output stabilizes, then posts the capture (timeout offers a continue button).
 - `/ctlc`: Slack command that sends Ctrl+C to the connected tmux pane.
 - `goslack.py`: Registers the current tmux pane with the target channel, cleans up duplicates, and supports `list`/`rm` (numbered), `--add`, and optional `--channel` override for session maintenance.
+  - `goslack.py notify`: receives Codex CLI `notify` JSON payload and posts it to the Slack channel mapped to the current tmux pane.
 
 ## Tips
 
@@ -283,6 +285,25 @@ codex() {
   command codex "$@"
 }
 ```
+
+### Codex CLI notify -> Slack
+
+Codex CLI can run an external program when a turn completes. Configure it to call `goslack.py notify`; the bridge polling (`/now`) remains unchanged.
+
+`~/.codex/config.toml`:
+
+```toml
+[notify]
+command = ["python", "/Users/you/WORKSPACE/slack_tmux_bridge/goslack.py", "notify"]
+```
+
+Codex passes one JSON argument to `notify` with keys like:
+- `thread-id`
+- `turn-id`
+- `input-messages`
+- `last-assistant-message`
+
+`goslack.py notify` resolves the current tmux `pane_id`, finds the mapped Slack channel in `active_sessions.json`, then replies to the latest Slack thread recorded for that pane. It posts only `last-assistant-message` as the thread body.
 
 Example (`/sessions` output):
 

--- a/docs/L3_implementation/specification.md
+++ b/docs/L3_implementation/specification.md
@@ -26,7 +26,7 @@
 | コンポーネント | 役割 |
 | --- | --- |
 | `slack_tmux_bridge.py` | Slackイベントを受け、tmuxに入力し、コマンド系の結果のみ返信するメインブリッジ |
-| `goslack.py` | tmux ペインと Slack チャンネルの対応表を書き込む |
+| `goslack.py` | tmux ペインと Slack チャンネルの対応表を書き込み、Codex notify を Slack に転送する |
 | `send_enter.sh` | tmux に Enter を送る最小ヘルパ |
 | `active_sessions.json` | Slack チャンネルID → pane_id/ペイン/ディレクトリ/チャンネル名のマッピング |
 | `tmp/` | スナップショット保存、PID ファイルなど |
@@ -56,6 +56,7 @@
 | `NOW_WATCH_INTERVAL_SEC` | `1` | `/now` 監視のポーリング間隔 | 出力変化の検知間隔を調整するため |
 | `NOW_WATCH_IDLE_COUNT` | `3` | `/now` の停止判定回数 | 変化が止まったとみなす閾値 |
 | `NOW_WATCH_TIMEOUT_SEC` | `180` | `/now` 監視タイムアウト | 変化が続く場合の打ち切りと継続促しのため |
+| `EXECUTE_RESULT_MODE` | `poll` | 実行ボタン押下後の結果取得方式 (`poll`/`notify`/`both`) | ポーリングと Codex notify の重複運用を制御するため |
 | `TMUX_BIN` | 省略時 `tmux` | tmux の絶対パス | PATH に tmux が無い場合（launchd など）に必要 |
 
 ---
@@ -85,10 +86,10 @@
 - `goslack.py list`: `active_sessions.json` の一覧を番号付きで表示（`num`, `channel_name`, `pane`, `pane_id`, `dir`）。
 - `goslack.py rm <number>`: 一覧の番号を指定して削除。
 - `goslack.py --add <pane>`: 別ペインから指定ペインを登録（対象ペインの `pane_current_path` を利用）。
-  - `--channel <NAME>` を併用した場合、チャンネル解決は指定名のみ（フォールバック無し）。
-  - 並び順は `ai-studio-01/02/03` が先頭（番号順）、それ以外はチャンネル名の昇順。
-  - チャンネル名が無い場合は `-` として扱われる。
-  - 番号が範囲外の場合はエラー終了する。
+- `goslack.py --add <pane> --channel <NAME>`: チャンネル解決を指定名のみに固定し、フォールバックを行わない。
+- `goslack.py list` の並び順: `ai-studio-01/02/03` が先頭（番号順）、それ以外はチャンネル名の昇順。チャンネル名が無い場合は `-`。
+- `goslack.py rm <number>`: 番号が範囲外の場合はエラー終了。
+- `goslack.py notify <payload>`: Codex CLI の `notify` JSON ペイロードを受け取り、現在の tmux ペインに紐づく Slack チャンネルへ通知する。
 
 #### 4.4.1 `list` の出力例
 
@@ -105,6 +106,12 @@ num	channel_name	pane	pane_id	dir
 ```
 python goslack.py rm 4
 ```
+
+### 4.5 Codex notify 連携
+- Codex CLI の `notify` は外部コマンドに JSON 文字列を 1 引数で渡す。
+- `goslack.py notify` は JSON から `thread-id`, `turn-id`, `last-assistant-message` を取り出して整形し、Slack に投稿する。
+- 投稿先は tmux の現在 `pane_id` と `active_sessions.json` の `pane_id` の一致で解決し、同じ `pane_id` に記録された最新の Slack `thread_ts` へ返信する。
+- `notify` は `/now` のポーリング挙動を変更しない。実行ボタンの監視有無は `EXECUTE_RESULT_MODE` に従う。
 
 ---
 
@@ -130,7 +137,7 @@ python goslack.py rm 4
 ### 5.3 入力の種類
 - **数字のみ**: 即実行（プリクリア → 入力 → Enter）。
 - **テキスト**: 受信時に tmux へ入力を送り、ボタンを表示。
-- 「▶︎ 実行（Enter）」で Enter 送信後、`/now` と同じ監視に入る。
+- 「▶︎ 実行（Enter）」で Enter 送信後、`EXECUTE_RESULT_MODE` が `poll` または `both` の場合に `/now` と同じ監視に入る。
   - 「👀 Geminiを見る」現在の tmux 出力を送信。
   - 「🗑️ プロンプト削除」Ctrl+U で入力行を消去。
 - **スラッシュコマンド**: `スラッシュコマンド` というメッセージによりボタンメニューを提示。
@@ -167,10 +174,10 @@ python goslack.py rm 4
 ## 7. 応答生成（コマンド系のみ）
 
 ### 7.1 `/now` と実行ボタンの監視取得
-- `/now` と「▶︎ 実行（Enter）」は `NOW_WATCH_INTERVAL_SEC` 間隔で tmux 出力を監視する。
+- `/now` は `NOW_WATCH_INTERVAL_SEC` 間隔で tmux 出力を監視する。
 - 連続 `NOW_WATCH_IDLE_COUNT` 回変化がなければ、`tmux capture-pane` で取得して返信する。
 - 変化が `NOW_WATCH_TIMEOUT_SEC` を超えて続く場合はタイムアウトを通知し、「監視を継続」ボタンを提示する。
-- 実行ボタンは Enter 送信後に監視し、停止したタイミングでスナップショットを投稿する。
+- 実行ボタンは `EXECUTE_RESULT_MODE` が `poll` または `both` の場合のみ、Enter 送信後に監視して停止タイミングでスナップショットを投稿する。
 
 ### 7.2 抽出ロジック
 1. `"> prompt"` 行を探し、その行以降のみ採用。

--- a/goslack.py
+++ b/goslack.py
@@ -13,6 +13,8 @@ from dotenv import load_dotenv
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 ACTIVE_SESSIONS_FILE = os.path.join(BASE_DIR, "active_sessions.json")
 DOTENV_PATH = os.path.join(BASE_DIR, ".env")
+TMP_DIR = os.path.join(BASE_DIR, "tmp")
+NOTIFY_CONTEXT_FILE = os.path.join(TMP_DIR, "notify_context.json")
 AI_STUDIO_CHANNELS = ["ai-studio-01", "ai-studio-02", "ai-studio-03"]
 
 # Load environment variables
@@ -100,11 +102,14 @@ def _get_slack_client():
         sys.exit(1)
     return WebClient(token=SLACK_BOT_TOKEN)
 
-def send_slack_message(channel, text):
+def send_slack_message(channel, text, thread_ts=None):
     """Sends a message to Slack using WebClient"""
     try:
         client = _get_slack_client()
-        client.chat_postMessage(channel=channel, text=text)
+        kwargs = {"channel": channel, "text": text}
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        client.chat_postMessage(**kwargs)
     except Exception as e:
         print(f"⚠️ Warning: Failed to send Slack message: {e}")
 
@@ -208,6 +213,88 @@ def _extract_pane(value):
         return value.get("pane_id") or value.get("pane")
     return value
 
+def _load_notify_context():
+    data = load_json(NOTIFY_CONTEXT_FILE)
+    if isinstance(data, dict):
+        return data
+    return {}
+
+def _find_notify_context_for_pane(pane_id):
+    context = _load_notify_context()
+    if not pane_id:
+        return None
+    value = context.get(pane_id)
+    if isinstance(value, dict):
+        return value
+    return None
+
+def _find_channel_id_by_pane_id(active_sessions, pane_id):
+    if not pane_id:
+        return None
+    for channel_id, value in active_sessions.items():
+        if isinstance(value, dict) and value.get("pane_id") == pane_id:
+            return channel_id
+    return None
+
+def _parse_notify_payload(raw_payload):
+    if not raw_payload:
+        return None
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+def _trim_notify_text(value, max_len=2800):
+    text = (value or "").strip()
+    if not text:
+        return ""
+    text = text.replace("```", "'''")
+    if len(text) > max_len:
+        text = text[:max_len] + "\n...(truncated)"
+    return text
+
+def _build_codex_notify_message(payload):
+    last_assistant_message = _trim_notify_text(payload.get("last-assistant-message", ""))
+    if last_assistant_message:
+        return last_assistant_message
+    return "(empty notify message)"
+
+def _read_notify_payload(arg_payload):
+    if arg_payload and arg_payload != "-":
+        return arg_payload
+    data = sys.stdin.read()
+    return data.strip() if data else ""
+
+def handle_notify(payload_arg):
+    raw_payload = _read_notify_payload(payload_arg)
+    payload = _parse_notify_payload(raw_payload)
+    if not payload:
+        print("⚠️ Warning: notify payload is not valid JSON object.")
+        return
+
+    if not os.environ.get("TMUX"):
+        print("⚠️ Warning: notify called outside tmux; skipped.")
+        return
+
+    pane_id = get_tmux_pane_id()
+    active_sessions = load_json(ACTIVE_SESSIONS_FILE)
+    channel_id = _find_channel_id_by_pane_id(active_sessions, pane_id)
+    if not channel_id:
+        print(f"⚠️ Warning: No active Slack mapping found for pane {pane_id}.")
+        return
+
+    notify_ctx = _find_notify_context_for_pane(pane_id) or {}
+    thread_ts = notify_ctx.get("thread_ts")
+    if not thread_ts:
+        print(f"⚠️ Warning: No thread_ts context found for pane {pane_id}.")
+        return
+
+    message = _build_codex_notify_message(payload)
+    send_slack_message(channel_id, message, thread_ts=thread_ts)
+
 def _rr_state_path():
     base_dir = os.path.dirname(ACTIVE_SESSIONS_FILE)
     return os.path.join(base_dir, "tmp", "ai_studio_rr.json")
@@ -295,6 +382,13 @@ def main():
         metavar="MESSAGE",
         help="Post a Slack message to the removed channel",
     )
+    notify_parser = subparsers.add_parser("notify", help="Receive Codex notify payload and post to mapped Slack channel")
+    notify_parser.add_argument(
+        "payload",
+        nargs="?",
+        default="-",
+        help="Codex notify JSON payload (if omitted or '-', read from stdin)",
+    )
     parser.add_argument("--add", metavar="PANE", help="Register a target tmux pane (e.g., 1:2.0)")
     parser.add_argument(
         "--channel",
@@ -309,6 +403,9 @@ def main():
         return
     if args.command == "rm":
         remove_sessions_by_number(args.number, notify_message=args.notify)
+        return
+    if args.command == "notify":
+        handle_notify(args.payload)
         return
 
     # 1. Get current directory (or target pane directory)

--- a/slack_tmux_bridge.py
+++ b/slack_tmux_bridge.py
@@ -34,6 +34,7 @@ ACTIVE_SESSIONS_FILE = os.path.join(BASE_DIR, "active_sessions.json")
 ENTER_SCRIPT = os.path.join(BASE_DIR, "send_enter.sh")
 TMP_DIR = os.path.join(BASE_DIR, "tmp")
 PID_FILE = os.path.join(TMP_DIR, "slack_tmux_bridge.pid")
+NOTIFY_CONTEXT_FILE = os.path.join(TMP_DIR, "notify_context.json")
 
 # Command filtering (comma-separated patterns; use "all" to match everything)
 COMMAND_ALLOWLIST = os.environ.get("COMMAND_ALLOWLIST", "all")
@@ -60,6 +61,9 @@ PERMISSION_WATCH_PATTERN = os.environ.get(
 NOW_WATCH_INTERVAL_SEC = float(os.environ.get("NOW_WATCH_INTERVAL_SEC", "1"))
 NOW_WATCH_IDLE_COUNT = int(os.environ.get("NOW_WATCH_IDLE_COUNT", "3"))
 NOW_WATCH_TIMEOUT_SEC = int(os.environ.get("NOW_WATCH_TIMEOUT_SEC", "180"))
+EXECUTE_RESULT_MODE = os.environ.get("EXECUTE_RESULT_MODE", "poll").lower()  # poll | notify | both
+if EXECUTE_RESULT_MODE not in {"poll", "notify", "both"}:
+    EXECUTE_RESULT_MODE = "poll"
 
 # =====================
 # logging & utility
@@ -377,6 +381,33 @@ def _load_active_sessions():
     except Exception as e:
         log(f"Error reading active sessions: {e}")
         return {}
+
+def _load_notify_context():
+    if not os.path.exists(NOTIFY_CONTEXT_FILE):
+        return {}
+    try:
+        with open(NOTIFY_CONTEXT_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+def _save_notify_context(context):
+    _atomic_write_json(NOTIFY_CONTEXT_FILE, context)
+
+def _record_notify_context(channel_id: str, thread_ts: str):
+    if not channel_id or not thread_ts:
+        return
+    sessions = _get_sessions()
+    entry = sessions.get(channel_id)
+    if not isinstance(entry, dict):
+        return
+    pane_id = entry.get("pane_id")
+    if not pane_id:
+        return
+    context = _load_notify_context()
+    context[pane_id] = {"channel_id": channel_id, "thread_ts": thread_ts, "updated_at": time.time()}
+    _save_notify_context(context)
 
 def _get_sessions():
     return _load_active_sessions()
@@ -1039,6 +1070,7 @@ def _handle_numeric_message(channel_id: str, thread_ts: str, tmux_target: str, t
     # ④ Enter送信
     send_enter(tmux_target, thread_ts=thread_ts, channel_id=channel_id)
     _start_permission_watch(thread_ts, channel_id, tmux_target)
+    _record_notify_context(channel_id, thread_ts)
 
 def _handle_text_message(channel_id: str, thread_ts: str, tmux_target: str, text: str):
     # ① 文字だけ tmux に送る
@@ -1048,6 +1080,7 @@ def _handle_text_message(channel_id: str, thread_ts: str, tmux_target: str, text
         thread_ts=thread_ts,
         channel_id=channel_id
     )
+    _record_notify_context(channel_id, thread_ts)
 
     # ② 同じメッセージのスレッドに操作ボタンを出す
     _post_message(
@@ -1169,7 +1202,9 @@ def handle_send_enter(ack, body):
     # Enterを送る
     send_enter(tmux_target, channel_id=channel_id)
     _start_permission_watch(thread_ts, channel_id, tmux_target)
-    _start_execute_watch(thread_ts, channel_id, tmux_target)
+    _record_notify_context(channel_id, thread_ts)
+    if EXECUTE_RESULT_MODE in ("poll", "both"):
+        _start_execute_watch(thread_ts, channel_id, tmux_target)
 
 # =====================
 # =====================

--- a/test/test_goslack_cli.py
+++ b/test/test_goslack_cli.py
@@ -49,3 +49,16 @@ def test_cli_rm_by_number(tmp_path, monkeypatch):
     assert "C2" not in sessions
     assert "C1" in sessions
     assert "C9" in sessions
+
+
+def test_cli_notify_calls_handler(monkeypatch):
+    called = {}
+
+    def _handle_notify(payload):
+        called["payload"] = payload
+
+    monkeypatch.setattr(goslack, "handle_notify", _handle_notify)
+    monkeypatch.setattr(sys, "argv", ["goslack.py", "notify", "{\"thread-id\":\"t1\"}"])
+    goslack.main()
+
+    assert called["payload"] == "{\"thread-id\":\"t1\"}"

--- a/test/test_goslack_main.py
+++ b/test/test_goslack_main.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -226,3 +227,96 @@ def test_select_fallback_round_robin_state(tmp_path, monkeypatch):
 
     name = goslack._select_fallback_channel(active_sessions)
     assert name == "ai-studio-01"
+
+
+def test_handle_notify_posts_to_mapped_channel(tmp_path, monkeypatch):
+    sessions_path = tmp_path / "active_sessions.json"
+    notify_context_path = tmp_path / "tmp" / "notify_context.json"
+    monkeypatch.setattr(goslack, "ACTIVE_SESSIONS_FILE", str(sessions_path))
+    monkeypatch.setattr(goslack, "NOTIFY_CONTEXT_FILE", str(notify_context_path))
+    goslack.save_json(
+        str(sessions_path),
+        {
+            "C1": {"pane": "1:1.0", "pane_id": "%1", "dir": "/tmp/a", "name": "chan-a"},
+        },
+    )
+    goslack.save_json(
+        str(notify_context_path),
+        {"%1": {"channel_id": "C1", "thread_ts": "123.456"}},
+    )
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux,123,0")
+    monkeypatch.setattr(goslack, "get_tmux_pane_id", lambda: "%1")
+
+    sent = {}
+    monkeypatch.setattr(
+        goslack,
+        "send_slack_message",
+        lambda ch, text, thread_ts=None: sent.update({"channel": ch, "text": text, "thread_ts": thread_ts}),
+    )
+
+    payload = json.dumps(
+        {
+            "thread-id": "thread-1",
+            "turn-id": "turn-1",
+            "input-messages": ["hello"],
+            "last-assistant-message": "done",
+        }
+    )
+    goslack.handle_notify(payload)
+
+    assert sent["channel"] == "C1"
+    assert sent["text"] == "done"
+    assert sent["thread_ts"] == "123.456"
+
+
+def test_handle_notify_skips_when_not_mapped(tmp_path, monkeypatch):
+    sessions_path = tmp_path / "active_sessions.json"
+    monkeypatch.setattr(goslack, "ACTIVE_SESSIONS_FILE", str(sessions_path))
+    goslack.save_json(
+        str(sessions_path),
+        {
+            "C1": {"pane": "1:1.0", "pane_id": "%1", "dir": "/tmp/a", "name": "chan-a"},
+        },
+    )
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux,123,0")
+    monkeypatch.setattr(goslack, "get_tmux_pane_id", lambda: "%9")
+    monkeypatch.setattr(goslack, "send_slack_message", lambda *_: (_ for _ in ()).throw(AssertionError("must not post")))
+
+    payload = json.dumps(
+        {
+            "thread-id": "thread-1",
+            "turn-id": "turn-1",
+            "input-messages": ["hello"],
+            "last-assistant-message": "done",
+        }
+    )
+    goslack.handle_notify(payload)
+
+
+def test_handle_notify_skips_when_thread_context_missing(tmp_path, monkeypatch):
+    sessions_path = tmp_path / "active_sessions.json"
+    notify_context_path = tmp_path / "tmp" / "notify_context.json"
+    monkeypatch.setattr(goslack, "ACTIVE_SESSIONS_FILE", str(sessions_path))
+    monkeypatch.setattr(goslack, "NOTIFY_CONTEXT_FILE", str(notify_context_path))
+    goslack.save_json(
+        str(sessions_path),
+        {
+            "C1": {"pane": "1:1.0", "pane_id": "%1", "dir": "/tmp/a", "name": "chan-a"},
+        },
+    )
+
+    monkeypatch.setenv("TMUX", "/tmp/tmux,123,0")
+    monkeypatch.setattr(goslack, "get_tmux_pane_id", lambda: "%1")
+    monkeypatch.setattr(goslack, "send_slack_message", lambda *_: (_ for _ in ()).throw(AssertionError("must not post")))
+
+    payload = json.dumps(
+        {
+            "thread-id": "thread-1",
+            "turn-id": "turn-1",
+            "input-messages": ["hello"],
+            "last-assistant-message": "done",
+        }
+    )
+    goslack.handle_notify(payload)

--- a/test/test_slack_bridge_sessions.py
+++ b/test/test_slack_bridge_sessions.py
@@ -711,3 +711,22 @@ def test_ctlc_command_dispatches_with_event_ts(monkeypatch):
     stb.handle_message(event, stb.logger)
 
     assert calls == [("C1", "123.456", "1:1.0")]
+
+
+def test_send_enter_skips_poll_watch_when_execute_mode_notify(monkeypatch):
+    called = {"execute_watch": 0, "record": 0}
+
+    monkeypatch.setattr(stb, "EXECUTE_RESULT_MODE", "notify")
+    monkeypatch.setattr(stb, "_get_tmux_target_or_notify", lambda *_args, **_kwargs: "1:1.0")
+    monkeypatch.setattr(stb, "_post_message", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(stb, "pre_clear_tmux", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(stb, "send_enter", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(stb, "_start_permission_watch", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(stb, "_record_notify_context", lambda *_args, **_kwargs: called.__setitem__("record", called["record"] + 1))
+    monkeypatch.setattr(stb, "_start_execute_watch", lambda *_args, **_kwargs: called.__setitem__("execute_watch", called["execute_watch"] + 1))
+
+    body = {"channel": {"id": "C1"}, "message": {"ts": "123.456"}}
+    stb.handle_send_enter(lambda: None, body)
+
+    assert called["record"] == 1
+    assert called["execute_watch"] == 0


### PR DESCRIPTION
## Summary
- add EXECUTE_RESULT_MODE (poll/notify/both) to control execute-button polling behavior
- route Codex notify messages as thread replies using pane-to-thread context
- post notify body using last-assistant-message in thread context
- update tests and docs for the new behavior

## Validation
- pytest -q test/test_goslack_main.py test/test_goslack_cli.py
- pytest -q (1 unrelated existing failure in test_launchd_assets.py)