### PR TITLE
#40 fix: unify notify destination — store and resolve thread_ts via goslack/active_sessions

### DIFF
--- a/goslack.py
+++ b/goslack.py
@@ -123,17 +123,17 @@ def _get_slack_client():
     return WebClient(token=SLACK_BOT_TOKEN)
 
 def send_slack_message(channel, text, thread_ts=None):
-    """Sends a message to Slack using WebClient"""
+    """Sends a message to Slack using WebClient. Returns ts of posted message or None."""
     try:
         client = _get_slack_client()
         kwargs = {"channel": channel, "text": text}
         if thread_ts:
             kwargs["thread_ts"] = thread_ts
-        client.chat_postMessage(**kwargs)
-        return True
+        resp = client.chat_postMessage(**kwargs)
+        return resp.get("ts")
     except Exception as e:
         print(f"⚠️ Warning: Failed to send Slack message: {e}")
-        return False
+        return None
 
 def _find_channel_by_name(client, name):
     cursor = None
@@ -291,7 +291,7 @@ def _resolve_channel_by_name(client, channel_name):
         return None
     return _find_channel_by_name(client, channel_name)
 
-def _register_session(target_channel, target_channel_name, pane_id, pane_target, cwd, pane_aliases=None):
+def _register_session(target_channel, target_channel_name, pane_id, pane_target, cwd, pane_aliases=None, thread_ts=None):
     active_sessions = load_json(ACTIVE_SESSIONS_FILE)
     pane_keys = {pane_id, pane_target}
     if pane_aliases:
@@ -304,12 +304,15 @@ def _register_session(target_channel, target_channel_name, pane_id, pane_target,
     for dup in duplicates:
         del active_sessions[dup]
 
-    active_sessions[target_channel] = {
+    entry = {
         "pane": pane_target,
         "pane_id": pane_id,
         "dir": cwd,
-        "name": target_channel_name
+        "name": target_channel_name,
     }
+    if thread_ts:
+        entry["thread_ts"] = thread_ts
+    active_sessions[target_channel] = entry
     save_json(ACTIVE_SESSIONS_FILE, active_sessions)
 
 def main():
@@ -384,16 +387,16 @@ def main():
     else:
         pane_aliases = []
     
-    # 5. Update active sessions
-    _register_session(target_channel, target_channel_name, pane_id, pane_target, cwd, pane_aliases=pane_aliases)
-    
-    # 6. Send Slack Notification
-    send_slack_message(
+    # 5. Send Slack Notification and capture thread_ts
+    ts = send_slack_message(
         target_channel,
         "✅ マッピングしました。"
         f"\nディレクトリ: {cwd}"
         "\nこのチャンネルからのメッセージはこの tmux ペインに送られます。"
     )
+
+    # 6. Update active sessions
+    _register_session(target_channel, target_channel_name, pane_id, pane_target, cwd, pane_aliases=pane_aliases, thread_ts=ts)
     
     print("✅ Mapped!")
     print(f"Directory: {cwd}")

--- a/slack_tmux_bridge.py
+++ b/slack_tmux_bridge.py
@@ -806,7 +806,11 @@ def _resolve_notify_destination(payload: dict):
                         continue
                     if value.get("pane_id") == pane_id:
                         channel_id = ch_id
+                        if not thread_ts:
+                            thread_ts = value.get("thread_ts")
                         break
+        if channel_id:
+            return channel_id, thread_ts
         ctx = context.get(pane_id) if isinstance(context, dict) else None
         if isinstance(ctx, dict):
             if not channel_id:

--- a/tests/test_slack_bridge_notify_ingress.py
+++ b/tests/test_slack_bridge_notify_ingress.py
@@ -109,18 +109,12 @@ def test_accept_notify_payload_queues_with_explicit_destination(tmp_path, monkey
 def test_accept_notify_payload_resolves_destination_by_pane_id(tmp_path, monkeypatch):
     _reset_ingress_state()
     sessions_path = tmp_path / "active_sessions.json"
-    notify_context_path = tmp_path / "tmp" / "notify_context.json"
     queue_path = tmp_path / "tmp" / "notify_delivery_queue.json"
     monkeypatch.setattr(stb, "ACTIVE_SESSIONS_FILE", str(sessions_path))
-    monkeypatch.setattr(stb, "NOTIFY_CONTEXT_FILE", str(notify_context_path))
     monkeypatch.setattr(stb, "NOTIFY_QUEUE_FILE", str(queue_path))
     stb._atomic_write_json(
         str(sessions_path),
-        {"C9": {"pane_id": "%9", "pane": "1:9.0", "dir": "/tmp/z", "name": "chan-z"}},
-    )
-    stb._atomic_write_json(
-        str(notify_context_path),
-        {"%9": {"channel_id": "C9", "thread_ts": "9.999", "updated_at": time.time()}},
+        {"C9": {"pane_id": "%9", "pane": "1:9.0", "dir": "/tmp/z", "name": "chan-z", "thread_ts": "9.999"}},
     )
 
     accepted, reason = stb._accept_notify_payload(
@@ -609,17 +603,11 @@ def test_run_notify_cli_resolves_channel_and_thread_by_pane_id(tmp_path, monkeyp
 def test_run_notify_cli_resolves_destination_by_tmux_pane_env(tmp_path, monkeypatch):
     captured = {}
     sessions_path = tmp_path / "active_sessions.json"
-    notify_context_path = tmp_path / "tmp" / "notify_context.json"
     monkeypatch.setattr(stb, "ACTIVE_SESSIONS_FILE", str(sessions_path))
-    monkeypatch.setattr(stb, "NOTIFY_CONTEXT_FILE", str(notify_context_path))
     monkeypatch.setenv("TMUX_PANE", "%1")
     stb._atomic_write_json(
         str(sessions_path),
-        {"C1": {"pane_id": "%1", "pane": "1:1.0", "dir": "/tmp/a", "name": "chan-a"}},
-    )
-    stb._atomic_write_json(
-        str(notify_context_path),
-        {"%1": {"channel_id": "C1", "thread_ts": "123.456", "updated_at": time.time()}},
+        {"C1": {"pane_id": "%1", "pane": "1:1.0", "dir": "/tmp/a", "name": "chan-a", "thread_ts": "123.456"}},
     )
 
     def _forward(raw):
@@ -634,20 +622,14 @@ def test_run_notify_cli_resolves_destination_by_tmux_pane_env(tmp_path, monkeypa
     assert payload["thread_ts"] == "123.456"
 
 
-def test_run_notify_cli_ignores_non_slack_thread_id_and_uses_context(tmp_path, monkeypatch):
+def test_run_notify_cli_ignores_non_slack_thread_id_and_uses_active_sessions(tmp_path, monkeypatch):
     captured = {}
     sessions_path = tmp_path / "active_sessions.json"
-    notify_context_path = tmp_path / "tmp" / "notify_context.json"
     monkeypatch.setattr(stb, "ACTIVE_SESSIONS_FILE", str(sessions_path))
-    monkeypatch.setattr(stb, "NOTIFY_CONTEXT_FILE", str(notify_context_path))
     monkeypatch.setenv("TMUX_PANE", "%1")
     stb._atomic_write_json(
         str(sessions_path),
-        {"C1": {"pane_id": "%1", "pane": "1:1.0", "dir": "/tmp/a", "name": "chan-a"}},
-    )
-    stb._atomic_write_json(
-        str(notify_context_path),
-        {"%1": {"channel_id": "C1", "thread_ts": "123.456", "updated_at": time.time()}},
+        {"C1": {"pane_id": "%1", "pane": "1:1.0", "dir": "/tmp/a", "name": "chan-a", "thread_ts": "123.456"}},
     )
 
     def _forward(raw):


### PR DESCRIPTION
Closes #40

## Summary

### Changed Files
- `goslack.py`: `send_slack_message()` now returns the `ts` of the posted message. `_register_session()` accepts `thread_ts` and stores it in `active_sessions.json`. The main flow sends the "マッピングしました" message first and passes its `ts` to `_register_session()`.
- `slack_tmux_bridge.py`: `_resolve_notify_destination()` now reads `thread_ts` from `active_sessions` when resolving by `pane_id`, and returns immediately without consulting `notify_context.json`.
- `tests/test_slack_bridge_notify_ingress.py`: Updated tests to place `thread_ts` in `active_sessions` (the new source of truth) instead of `notify_context`.

### Change Type
- [x] fix (bug fix)

### Handoff Notes for /docs-sync
- Design intent: `goslack.py` is the single source of truth for both channel and thread assignment. The `notify_context.json` lookup for `thread_ts` is bypassed once `active_sessions` resolves the channel — this eliminates the bootstrap problem where the first stop hook notification had no `thread_ts` and posted to the channel root.
- Side effects not visible in git diff: `active_sessions.json` entries will now include a `thread_ts` field after `goslack.py` registers a session. Existing entries without `thread_ts` (from before this change) will result in top-level posts until re-registered.
- Potential misreads by docs-sync: The `send_slack_message()` return value change (was `True/False`, now `ts/None`) — callers other than `main()` (e.g. `remove_sessions_by_number()`) ignore the return value, so no behavior change there.
- Specific docs sections to update: `specification_summary.md` — "チャンネルとペインの対応管理" and "notify 宛先解決" sections need to reflect the new `thread_ts` flow.

## Notes for Reviewers
The early return at `if channel_id: return channel_id, thread_ts` after the `active_sessions` loop is the key change — it prevents falling through to `notify_context.json` for `thread_ts` resolution when `active_sessions` already knows the session.

## Docs Sync Result
- Updated files: `docs/L3_implementation/specification_summary.md`
- Changes: `active_sessions.json` schema updated to include `thread_ts`; notify destination resolution updated to reflect goslack as single source of truth
- Basis: git diff main...HEAD adopted as fact, PR handoff notes referenced as supplement
- HARD STOP: none